### PR TITLE
Remove reference to ~/Library/Keyboard Layouts/ in README.txt

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -4,8 +4,9 @@ Workman keyboard layout for MacOS
 Workman and Workman-P Mac OSX keyboard layout packaged as a keylayout bundle includes alternate icons, similar in style to the system icons for other layouts like Dvorak or Colemak.
 
 ## Installation
-
- * Download the keyboard layout bundle to the /Library/Keyboard Layouts/ directory.
+* Download the keyboard layout bundle and place it in one of the following locationsI
+	* /Library/Keyboard Layouts/ - Makes Workman available system wide
+	* ~/Library/Keyboard Layouts/ -  (**discouraged**) This will only setup Workman for the current user. Therefore the layout would not be available as an input device on the Mac OS X login screen and other system level dialogs.
  * Log out of OS X and log back in.
  * Open System Preferences, click on the Language & Text icon, and in the Input Menu tab enable the Workman and/or Workman-P layout.
  * Make sure that the Show input menu in menu bar box is also checked.


### PR DESCRIPTION
If Workman.bundle is only placed in the "~/Library/Keyboard Layouts/" directory then Workman is not listed as an option as an input source on Mac OS X login screen. Therefore it does not make much sense to list it as an option.
