### PR TITLE
Remove dead links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Use it, implement it, integrate it, create tools for it, etc. Have a go at it. Y
 However, if you do use or implement the Workman Layout (i.e. arrangement of the keys) in some way or fashion, attribution to OJ Bucao as the creator is requested and a link back to this blog. This means that if you have an Workman Layout implementation/installation file that you created for some platform or OS, please put somewhere in the file something like the following:
 
 The Workman Keyboard Layout created by OJ Bucao.
-www.workmanlayout.com
+https://workmanlayout.org
 
 Also if you use content from my blog or articles or quote me directly, please use proper citation .
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Workman keyboard layouts
 ========================
 
-Workman keyboard layout originally proposed by OJ Bucao at http://www.workmanlayout.org.
+Workman keyboard layout originally proposed by OJ Bucao at https://workmanlayout.org.
 
 When learning cold-turkey, try printing the included keyboard image as a desk reference.
 

--- a/freebsd_console/us.workman-p.acc.kbd
+++ b/freebsd_console/us.workman-p.acc.kbd
@@ -1,7 +1,6 @@
 # $FreeBSD$
 # Based on FreeBSD's us.iso.acc.kbd
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
 # code  base   shift  cntrl  shift  alt    shift  cntrl  shift state

--- a/freebsd_console/us.workman-p.kbd
+++ b/freebsd_console/us.workman-p.kbd
@@ -1,7 +1,6 @@
 # $FreeBSD$
 # Based on FreeBSD's us.iso.kbd
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
 # code  base   shift  cntrl  shift  alt    shift  cntrl  shift state

--- a/freebsd_console/us.workman.acc.kbd
+++ b/freebsd_console/us.workman.acc.kbd
@@ -1,7 +1,6 @@
 # $FreeBSD$
 # Based on FreeBSD's us.iso.acc.kbd
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
 # code  base   shift  cntrl  shift  alt    shift  cntrl  shift state

--- a/freebsd_console/us.workman.kbd
+++ b/freebsd_console/us.workman.kbd
@@ -1,5 +1,5 @@
 # $FreeBSD$
-# 09-06-2010 OJ Bucao. http://www.workmanlayout.com
+# 09-06-2010 OJ Bucao. https://workmanlayout.org
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
 # code  base   shift  cntrl  shift  alt    shift  cntrl  shift state

--- a/freebsd_console/workman-p.iso15.acc.kbd
+++ b/freebsd_console/workman-p.iso15.acc.kbd
@@ -1,7 +1,6 @@
 # $FreeBSD$
 # Based on FreeBSD's colemak.iso15.acc.kbd
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock

--- a/freebsd_console/workman.iso15.acc.kbd
+++ b/freebsd_console/workman.iso15.acc.kbd
@@ -1,7 +1,6 @@
 # $FreeBSD$
 # Based on FreeBSD's colemak.iso15.acc.kbd
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock

--- a/linux_console/workman-p.iso15.kmap
+++ b/linux_console/workman-p.iso15.kmap
@@ -1,6 +1,5 @@
 # workman-p.kmap for Linux console.
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 alt_is_meta
 charset "iso-8859-15"  # use a ISO-8859-15 font, e.g.: consolechars -f lat9v-14
 keymaps 0-12

--- a/linux_console/workman.iso15.kmap
+++ b/linux_console/workman.iso15.kmap
@@ -1,6 +1,5 @@
 # workman.kmap for Linux console.
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 alt_is_meta
 charset "iso-8859-15"  # use a ISO-8859-15 font, e.g.: consolechars -f lat9v-14
 keymaps 0-12

--- a/netbsd_console/pckbd.workman-p.iso8859-1
+++ b/netbsd_console/pckbd.workman-p.iso8859-1
@@ -1,6 +1,5 @@
 # Workman-P keymap for NetBSD console.
-# http://workman.ws/
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 # copy to /usr/share/wscons/keymaps/pckbd.workman-p.iso8859-1
 # modify the mapfile setting in /etc/wscons.conf
 

--- a/netbsd_console/pckbd.workman.iso8859-1
+++ b/netbsd_console/pckbd.workman.iso8859-1
@@ -1,7 +1,6 @@
 # Workman keymap for NetBSD console.
 # 09-06-2010 OJ Bucao. Public domain.
-# http://workman.ws/
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 # copy to /usr/share/wscons/keymaps/pckbd.workman.iso8859-1
 # modify the mapfile setting in /etc/wscons.conf
 

--- a/openbsd_console/workman-p_openbsd.sh
+++ b/openbsd_console/workman-p_openbsd.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Workman-P layout script for OpenBSD console.
-# http://workman.ws/
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 wsconsctl keyboard.encoding=us  \
     keyboard.map+="keycode  41 =          grave    asciitilde       dead_tilde        asciitilde " \

--- a/openbsd_console/workman_openbsd.sh
+++ b/openbsd_console/workman_openbsd.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # Workman layout script for OpenBSD console.
 # 09-06-2010 OJ Bucao. Public domain.
-# http://workman.ws/
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 wsconsctl keyboard.encoding=us  \
     keyboard.map+="keycode  41 =          grave    asciitilde       dead_tilde        asciitilde " \

--- a/solaris_console/type_6/workman
+++ b/solaris_console/type_6/workman
@@ -1,6 +1,5 @@
 # Workman Type 6 (USB) key layout for Solaris console.
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 key 53	 base ` shift ~ caps ` ctrl ^^ altg fa_tilde
 key 30	 base 1 shift ! caps 1 ctrl 1 altg ¡

--- a/solaris_console/type_6/workman-p
+++ b/solaris_console/type_6/workman-p
@@ -1,6 +1,5 @@
 # Workman-P Type 6 (USB) key layout for Solaris console.
-# http://workman.ws
-# http://www.workmanlayout.com
+# https://workmanlayout.org
 
 key 53	 base ` shift ~ caps ` ctrl ^^ altg fa_tilde
 key 30	 base ! shift 1 caps ! ctrl 1 altg ¡

--- a/windows/pkl/workman-p/layout.ini
+++ b/windows/pkl/workman-p/layout.ini
@@ -11,7 +11,7 @@ localeid             = 00000409
 
 copyright            = Public Domain
 company              = 2010-09-06 OJ Bucao
-homepage             = http://www.workmanlayout.com
+homepage             = https://workmanlayout.org
 version              = 1.0
 
 generated_at         = Fri Jan 6 19:18:00 2011

--- a/windows/pkl/workman/layout.ini
+++ b/windows/pkl/workman/layout.ini
@@ -11,7 +11,7 @@ localeid             = 00000409
 
 copyright            = Public Domain
 company              = 2010-09-06 OJ Bucao
-homepage             = http://www.workmanlayout.com
+homepage             = https://workmanlayout.org
 version              = 1.0
 
 generated_at         = Fri Jan 6 19:18:00 2011

--- a/xfree86/workman
+++ b/xfree86/workman
@@ -1,6 +1,5 @@
 // Workman symbols for xkb on XFree86 and X.Org server 6.x (old)
-// http://workman.ws
-// http://www.workmanlayout.com
+// https://workmanlayout.org
 
 partial default alphanumeric_keys
 xkb_symbols "basic" {

--- a/xfree86/workman-p
+++ b/xfree86/workman-p
@@ -1,6 +1,5 @@
 // Workman symbols for xkb on XFree86 and X.Org server 6.x (old)
-// http://workman.ws
-// http://www.workmanlayout.com
+// https://workmanlayout.org
 
 partial default alphanumeric_keys
 xkb_symbols "basic" {

--- a/xmodmap/xmodmap.workman
+++ b/xmodmap/xmodmap.workman
@@ -1,6 +1,5 @@
 ! xmodmap for the Workman layout.
-! http://workman.ws
-! http://www.workmanlayout.com
+! https://workmanlayout.org
 
 keycode  49 =        grave    asciitilde       dead_tilde        asciitilde            
 keycode  10 =            1        exclam       exclamdown       onesuperior            

--- a/xmodmap/xmodmap.workman-p
+++ b/xmodmap/xmodmap.workman-p
@@ -1,6 +1,5 @@
 ! xmodmap for the Workman layout.
-! http://workman.ws
-! http://www.workmanlayout.com 
+! https://workmanlayout.org
 
 keycode  49 =        grave    asciitilde       dead_tilde        asciitilde            
 keycode  10 =       exclam             1       exclamdown       onesuperior            

--- a/xorg/workman
+++ b/xorg/workman
@@ -1,5 +1,5 @@
 // Workman Keyboard Layout symbols for xkb on X.Org Server 7.x
-// 09-06-2010 OJ Bucao. http://www.workmanlayout.com
+// 09-06-2010 OJ Bucao. https://workmanlayout.org
 
 partial alphanumeric_keys
 xkb_symbols "workman" {

--- a/xorg/workman-p
+++ b/xorg/workman-p
@@ -1,5 +1,5 @@
 // Workman-P Keyboard Layout symbols for xkb on X.Org Server 7.x
-// 09-06-2010 OJ Bucao. http://www.workmanlayout.com
+// 09-06-2010 OJ Bucao. https://workmanlayout.org
 
 partial alphanumeric_keys
 xkb_symbols "workman-p" {


### PR DESCRIPTION
Removed links to websites that are not longer active (`workman.ws` and `workmanlayout.com`).  Updated all links to https://workmanlayout.org .